### PR TITLE
Calculate rolling candlestick and mean data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,9 +78,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "cc"
@@ -101,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.6"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -118,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.6"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -131,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -164,10 +173,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.3"
+name = "crossbeam-channel"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -206,10 +260,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
+name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -221,12 +281,18 @@ dependencies = [
  "bincode",
  "chrono",
  "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
  "csv",
  "futures",
  "futures-channel",
  "futures-util",
+ "once_cell",
+ "rayon",
+ "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
  "tokio-tungstenite",
  "url",
@@ -375,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -497,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,15 +632,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -595,9 +670,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -608,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "parking_lot"
@@ -691,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
 dependencies = [
  "unicode-ident",
 ]
@@ -738,12 +813,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.13"
+name = "rayon"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -753,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +876,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "ryu"
@@ -808,18 +930,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -828,13 +950,39 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -859,15 +1007,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -973,10 +1124,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1014,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -1028,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64",
  "byteorder",
@@ -1060,15 +1212,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,26 @@
 name = "finnhub_ws"
 version = "0.1.0"
 edition = "2021"
+authors = ["Pavlos Karakalidis <p.karakal@outlook.com>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bincode = "1.3.3"
-clap = { version = "3.2.6", features = ["derive"] }
+clap = { version = "3.2.6", features = ["cargo", "derive", "env"] }
 csv = "1.1"
 chrono = { version = "0.4.19", features = ["serde"] }
+crossbeam-channel = "0.5.5"
+crossbeam-utils = "0.8.10"
 futures = "0.3.21"
 futures-channel = "0.3.21"
 futures-util = "0.3.21"
+once_cell = "1.13.0"
+rayon = "1.5"
+regex = "1.6.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+serial_test = "0.8.0"
 tokio = { version = "1.19.2", features = ["full"] }
 tokio-tungstenite = { version = "0.17.1", features = ["native-tls"] }
 url = "2.2.2"

--- a/src/candlestick.rs
+++ b/src/candlestick.rs
@@ -1,0 +1,63 @@
+use std::fs::File;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use crate::{RollingData};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Candlestick{
+    #[serde(rename = "Symbol")]
+    pub stock_symbol: String,
+    #[serde(rename = "MinuteOfDay")]
+    pub minute_of_hour: DateTime<Utc>,
+    #[serde(rename = "OpenPrice")]
+    pub open_price: f64,
+    #[serde(rename = "ClosePrice")]
+    pub close_price: f64,
+    #[serde(rename = "HighestPrice")]
+    pub highest_price: f64,
+    #[serde(rename = "LowestPrice")]
+    pub lowest_price: f64,
+    #[serde(rename = "Transactions")]
+    pub total_transactions: u64
+}
+
+impl Candlestick{
+    pub fn default() -> Self {
+        Candlestick {
+            open_price: 0.0,
+            close_price: 0.0,
+            highest_price: 0.0,
+            lowest_price: 0.0,
+            total_transactions: 0,
+            stock_symbol: "".parse().unwrap(),
+            minute_of_hour: Utc::now(),
+        }
+    }
+
+    fn new(open: f64, close: f64, high: f64, low: f64, count: u64, minute: DateTime<Utc>, symbol: String) -> Self {
+        Candlestick {
+            open_price: open,
+            close_price: close,
+            highest_price: high,
+            lowest_price: low,
+            total_transactions: count,
+            stock_symbol: symbol,
+            minute_of_hour: minute,
+        }
+    }
+    pub fn write_to_file(&self, file: &File){
+        let mut writer = csv::WriterBuilder::new().has_headers(false).from_writer(file);
+        writer.serialize(self).unwrap();
+        writer.flush().unwrap();
+    }
+}
+
+pub fn calculate_candlestick(data: &[RollingData]) -> Option<Candlestick> {
+    if !data.is_empty(){
+        let max_price = data.iter().map(|x| { x.price }).max_by(|a,b| a.partial_cmp(b).unwrap()).unwrap();
+        let min_price = data.iter().map(|x| { x.price }).min_by(|a,b| a.partial_cmp(b).unwrap()).unwrap();
+        return Some(Candlestick::new(data[0].price, data[data.len()-1].price, max_price, min_price, data.len() as u64, Utc::now(), data[0].symbol.parse().unwrap()));
+    }
+    None
+}
+

--- a/src/cli/cmd.rs
+++ b/src/cli/cmd.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "finnhub_ws", version = "0.1.0", author = env ! ("CARGO_PKG_AUTHORS"))]
+#[clap(name = env!("CARGO_PKG_NAME"), version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 pub struct CLIOptions {
     #[clap(short, long)]
     pub verbose: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod cli;
-use std::{fs::{File, OpenOptions, create_dir_all}, io::{Error}, path::{Path, PathBuf}, fmt::format, io};
-use std::io::Write;
+pub mod stock_handle;
+pub mod utils;
+pub mod candlestick;
+pub mod mean;
+use std::{fs::{File, OpenOptions, create_dir_all}, path::{PathBuf}, io};
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, NaiveDateTime, Utc, serde::{ts_milliseconds}};
-use csv;
 use csv::StringRecord;
 
 
@@ -42,17 +44,39 @@ pub struct Response<'a> {
     pub transaction_data: Vec<TickerInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum WsMessage {
-    Error {
-        #[serde(rename = "msg")]
-        message: String,
-    },
-    Ping,
-    Response,
+#[derive(Deserialize, Debug, Serialize)]
+pub struct Ping<'a> {
+    #[serde(rename = "type")]
+    pub action_type: &'a str
 }
 
+#[derive(Deserialize, Debug, Serialize)]
+pub struct WsError<'a> {
+    #[serde(rename = "msg")]
+    pub message: &'a str
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged, rename_all = "lowercase")]
+pub enum WsMessage<'a> {
+    #[serde(borrow = "'a")]
+    Response(Response<'a>),
+    #[serde(borrow = "'a")]
+    Error(WsError<'a>),
+    #[serde(borrow = "'a")]
+    Ping(Ping<'a>)
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct RollingData {
+    pub symbol: String,
+    pub price: f64,
+    #[serde(with = "ts_milliseconds")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(with = "ts_milliseconds")]
+    pub write_timestamp: DateTime<Utc>
+}
 
 impl TickerInfo {
     fn default() -> Self {
@@ -75,17 +99,13 @@ impl TickerInfo {
         }
     }
 
-    pub fn write_to_disk(&self, path: &PathBuf) {
-        let file = self.check_file_exists(path);
-        if self.check_file_empty(&file) {
-            self.write_headers(&file);
-        }
-        let mut writer = csv::WriterBuilder::new().has_headers(true).from_writer(&file);
+    pub fn write_to_disk(&self, file: &File) {
+        let mut writer = csv::WriterBuilder::new().has_headers(true).from_writer(file);
         writer.serialize(self.vectorize()).unwrap();
         writer.flush().unwrap();
     }
 
-    fn check_file_empty(&self, file: &File) -> bool {
+    pub fn check_file_empty(&self, file: &File) -> bool {
         // has headers has been set to false as it will skip the first record
         let mut reader = csv::ReaderBuilder::new().has_headers(false).from_reader(file);
         let mut rec = StringRecord::new();
@@ -111,14 +131,13 @@ impl TickerInfo {
                         .unwrap();
                     self.write_headers(&f);
                     f
-                },
-                _ => panic!("Problem opening the file" )
-
+                }
+                _ => panic!("Problem opening the file")
             }
         }
     }
 
-    fn write_headers(&self, f: &File) {
+    pub fn write_headers(&self, f: &File) {
         let mut writer = csv::WriterBuilder::new().has_headers(true).from_writer(f);
         writer.serialize(self.get_headers()).unwrap();
         writer.flush().unwrap();
@@ -129,28 +148,28 @@ impl CSVAble for TickerInfo {
     fn vectorize(&self) -> Vec<String> {
         return vec![self.symbol.clone(),
                     self.price.to_string(),
-                    self.time.timestamp_nanos().to_string(),
-                    Utc::now().timestamp_nanos().to_string(),
+                    self.time.timestamp_millis().to_string(),
+                    Utc::now().timestamp_millis().to_string(),
         ];
     }
     fn get_headers(&self) -> Vec<String> {
         return vec!["Symbol".to_string(),
                     "Price".to_string(),
                     "Timestamp".to_string(),
-                    "Write Timestamp".to_string()];
+                    "WriteTimestamp".to_string()];
     }
 }
 
-impl <'a> Response<'a> {
-    pub fn default() -> Self{
-        Response{
+impl<'a> Response<'a> {
+    pub fn default() -> Self {
+        Response {
             transaction_type: "trade",
             transaction_data: vec![],
         }
     }
 }
 
-impl <'a> SubscribeInfo<'a> {
+impl<'a> SubscribeInfo<'a> {
     pub fn new(symbol: &'a str) -> Self {
         SubscribeInfo {
             message_type: "subscribe",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
-use std::fmt::format;
-use std::path::{Path, PathBuf};
-use futures_util::{SinkExt, StreamExt};
-use futures_util::stream::SplitSink;
-use tokio::io::{AsyncWriteExt};
-use tokio::net::TcpStream;
+use std::process::exit;
+use std::sync::Arc;
+use chrono::{DurationRound};
+use futures_util::{SinkExt, StreamExt, stream::{SplitSink, SplitStream}};
+use tokio::{net::TcpStream, time::{self, Duration}};
 use tokio_tungstenite::{connect_async, MaybeTlsStream, tungstenite::protocol::Message, WebSocketStream};
-use finnhub_ws::{cli::cmd::CLIOptions, Response, SubscribeInfo};
+use finnhub_ws::{cli::cmd::CLIOptions, Response, SubscribeInfo, WsMessage, candlestick::calculate_candlestick, stock_handle::{initialize_mapper, StockHandle}, mean::calculate_mean_data, utils::{create_dirs, find_items}};
 use clap::Parser;
+use rayon::prelude::*;
+use crossbeam_channel::{Sender};
+use finnhub_ws::candlestick::Candlestick;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -22,17 +24,96 @@ async fn main() -> Result<()> {
 
     let (write, read) = ws_stream.split();
 
-    subscribe_to_stocks(write, &opts.stocks).await;
-
-
-    let read_future = read.for_each(|message| async {
-        let x = &*message.unwrap().into_data();
-        let data = serde_json::from_slice::<Response>(x).unwrap();
-        parse_message(&data)
+    let dirs = vec!["data/rolling", "data/candlestick", "data/mean"];
+    dirs.iter().for_each(|x| {
+        if !create_dirs(x) {
+            eprintln!("Couldn't create directories");
+            exit(1);
+        }
     });
 
-    read_future.await;
+    let mapper = initialize_mapper(&opts.stocks);
+
+    let mapper_a = Arc::clone(&mapper);
+    let mapper_b = Arc::clone(&mapper);
+    let mapper_c = Arc::clone(&mapper);
+    subscribe_to_stocks(write, &opts.stocks).await;
+    let futures_vec = vec![
+        tokio::spawn(async move {
+            read_from_stream(read, &mapper_c).await;
+        }),
+        tokio::spawn(async move {
+        let candlestick_txs: Vec<Sender<i64>> = mapper_a.iter().map(|x| {
+            let (tx, _) = x.stock_channel.clone();
+            tx
+        }).collect();
+        let mean_txs: Vec<Sender<i64>> = mapper_a.iter().map(|x| {
+            let (tx, _) = x.rolling_mean_channel.clone();
+            tx
+        }).collect();
+        tick(&candlestick_txs, &mean_txs).await;
+    }), tokio::spawn(async move {
+        let cs_pool = rayon::ThreadPoolBuilder::new().num_threads(2 * mapper_b.len()).build().unwrap();
+        cs_pool.install(|| {
+            mapper_b.par_iter().for_each(|x| {
+                rayon::join(|| wait_for_candlestick(x), || wait_for_mean(x));
+            });
+        });
+    })];
+
+    futures::future::join_all(futures_vec).await;
     Ok(())
+}
+
+async fn tick(candlestick_txs: &[Sender<i64>], mean_txs: &[Sender<i64>]) {
+    let mut interval = time::interval(Duration::from_secs(60));
+    interval.tick().await;
+    loop {
+        interval.tick().await;
+        for (_, (cs_tx, me_tx)) in candlestick_txs.iter().zip(mean_txs.iter()).enumerate() {
+            let timestamp = chrono::Local::now().duration_trunc(chrono::Duration::minutes(1)).unwrap().timestamp();
+            cs_tx.send(timestamp).unwrap();
+            me_tx.send(timestamp).unwrap();
+        }
+    }
+}
+
+async fn read_from_stream(read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>, mapper: &Vec<StockHandle>) {
+    let reader = read.for_each(|message| async {
+        let x = &*message.unwrap().into_data();
+        let data = serde_json::from_slice::<WsMessage>(x).unwrap();
+        match data {
+            WsMessage::Response(resp) => { parse_message(&resp, mapper) }
+            WsMessage::Ping(ping) => println!("{:?}", ping),
+            WsMessage::Error(err) => println!("{:?}", err.message)
+        }
+    });
+    reader.await;
+}
+
+fn wait_for_candlestick(handle: &StockHandle) {
+    let (_, rx) = handle.rolling_mean_channel.clone();
+    loop {
+        let timestamp = rx.recv().unwrap();
+        let mut rf = handle.rolling_file.lock().unwrap();
+        let items = find_items(&mut rf, timestamp, 1);
+        drop(rf);
+        let cf = handle.candlestick_file.lock().unwrap();
+        match calculate_candlestick(&items) {
+            Some(cs) => {
+                cs.write_to_file(&cf);
+                drop(cs);
+                drop(items);
+                drop(cf);
+            }
+            None => {
+                drop(items);
+                drop(cf);
+            }
+        };
+    }
+}
+
 }
 
 async fn subscribe_to_stocks(mut tx: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>, stocks: &[String]) {
@@ -49,8 +130,19 @@ async fn subscribe_to_stocks(mut tx: SplitSink<WebSocketStream<MaybeTlsStream<Tc
     }
 }
 
-fn parse_message(resp: &Response) {
-    resp.transaction_data.iter().for_each(|x|  {
-        x.write_to_disk(&PathBuf::from(format!("data/{}.csv", x.symbol)));
+fn parse_message(resp: &Response, mapper: &Vec<StockHandle>) {
+    resp.transaction_data.par_iter().for_each(|x| {
+        match mapper.iter().find(|s| s.stock_symbol == x.symbol) {
+            Some(handle) => {
+                handle.once_flag.call_once(|| {
+                    let rf = handle.rolling_file.lock().unwrap();
+                    if x.check_file_empty(&rf) {
+                        x.write_headers(&rf)
+                    }
+                });
+                x.write_to_disk(&handle.rolling_file.lock().unwrap())
+            }
+            None => {}
+        }
     });
 }

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -1,0 +1,41 @@
+use std::fs::File;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use crate::RollingData;
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MeanData {
+    pub symbol: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub mean_price: f64,
+    pub transactions: u64
+}
+
+impl MeanData {
+    fn new(start_time: DateTime<Utc>, end_time: DateTime<Utc>, mean_price: f64, transactions: u64, symbol: String) -> Self {
+        MeanData {
+            symbol,
+            transactions,
+            mean_price,
+            start_time,
+            end_time
+        }
+    }
+    pub fn write_to_file(&self, file: &File){
+        let mut writer = csv::WriterBuilder::new().has_headers(false).from_writer(file);
+        writer.serialize(self).unwrap();
+        writer.flush().unwrap();
+    }
+}
+
+pub fn calculate_mean_data(data: &[RollingData]) -> Option<MeanData> {
+    if !data.is_empty(){
+        let max_date = data.iter().map(|x| { x.write_timestamp }).max_by(|a,b| a.partial_cmp(b).unwrap()).unwrap();
+        let min_date = data.iter().map(|x| { x.write_timestamp }).min_by(|a,b| a.partial_cmp(b).unwrap()).unwrap();
+        let mean_price: f64 = data.iter().fold(0.0, |mean_price, i| mean_price + i.price) /( data.len() as f64);
+        return Some(MeanData::new(min_date, max_date, mean_price, data.len() as u64, data[0].symbol.parse().unwrap()));
+    }
+    None
+}

--- a/src/stock_handle.rs
+++ b/src/stock_handle.rs
@@ -1,0 +1,129 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::io::{Seek, SeekFrom};
+use std::sync::{Arc, Mutex, Once};
+use chrono::{Utc};
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use crate::candlestick::Candlestick;
+use crate::TickerInfo;
+use crate::utils::sanitize_string;
+
+#[derive(Debug)]
+pub struct StockHandle {
+    pub stock_symbol: String,
+    pub rolling_file: Mutex<File>,
+    pub candlestick_file: Mutex<File>,
+    pub mean_file: Mutex<File>,
+    pub once_flag: Once,
+    pub stock_channel: (Sender<i64>, Receiver<i64>),
+    pub rolling_mean_channel: (Sender<i64>, Receiver<i64>)
+}
+
+pub fn create_rolling_file(stock: &str) -> Option<File> {
+    let safe_stock = sanitize_string(stock);
+    match OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .read(true)
+        .open(format!("data/rolling/{}.csv", safe_stock)) {
+        Ok(f) => Some(f),
+        Err(err) => match err.kind() {
+            io::ErrorKind::PermissionDenied => {
+                eprintln!("Cannot create a file due to permission reasons");
+                None
+            }
+            _ => {
+                eprintln!("Couldn't create file");
+                None
+            }
+        }
+    }
+}
+
+pub fn create_candlestick_file(stock: &str) -> Option<File> {
+    let safe_stock = sanitize_string(stock);
+    match OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .read(true)
+        .open(format!("data/candlestick/{}.csv", safe_stock)) {
+        Ok(f) => Some(f),
+        Err(err) => match err.kind() {
+            io::ErrorKind::PermissionDenied => {
+                eprintln!("Cannot create a file due to permission reasons");
+                None
+            }
+            _ => {
+                eprintln!("Couldn't create file");
+                None
+            }
+        }
+    }
+}
+
+pub fn create_mean_file(stock: &str) -> Option<File> {
+    let safe_stock = sanitize_string(stock);
+    match OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .read(true)
+        .open(format!("data/mean/{}.csv", safe_stock)) {
+        Ok(f) => Some(f),
+        Err(err) => match err.kind() {
+            io::ErrorKind::PermissionDenied => {
+                eprintln!("Cannot create a file due to permission reasons");
+                None
+            }
+            _ => {
+                eprintln!("Couldn't create file");
+                None
+            }
+        }
+    }
+}
+
+pub fn initialize_mapper(stocks: &[String])-> Arc<Vec<StockHandle>>{
+    let mut mapper = Vec::with_capacity(stocks.len());
+    stocks.iter().for_each(|x| {
+        let rolling = create_rolling_file(x.as_str()).unwrap();
+        let candlestick = create_candlestick_file(x.as_str()).unwrap();
+        let mean = create_mean_file(x.as_str()).unwrap();
+        let res = StockHandle{
+            stock_symbol: x.to_string(),
+            rolling_file: Mutex::new(rolling),
+            candlestick_file: Mutex::new(candlestick),
+            mean_file: Mutex::new(mean),
+            once_flag: Once::new(),
+            stock_channel: unbounded(),
+            rolling_mean_channel: unbounded()
+        };
+        res.once_flag.call_once(||{
+            let t = TickerInfo::default();
+            let rf = res.rolling_file.lock().unwrap();
+            if t.check_file_empty(&rf) {
+                t.write_headers(&rf);
+            }
+            drop(rf);
+            let cf = res.candlestick_file.lock().unwrap();
+            let c = Candlestick{
+                open_price: 0.0,
+                close_price: 0.0,
+                highest_price: 0.0,
+                lowest_price: 0.0,
+                total_transactions: 0,
+                minute_of_hour: Utc::now(),
+                stock_symbol: "".parse().unwrap()
+            };
+            c.write_to_file(&cf);
+            drop(cf);
+        });
+        mapper.push(res);
+    });
+    Arc::new(mapper)
+}
+
+
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,179 @@
+use std::fs::{create_dir_all, File};
+use std::io;
+use std::io::{BufReader, Read, Seek, SeekFrom};
+use serde::{Deserialize};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use regex::Regex;
+use crate::{RollingData};
+
+pub fn sanitize_string(s: &str) -> String {
+    let re = Regex::new(r"\W").unwrap();
+    re.replace_all(s, "_").to_string()
+}
+
+pub fn create_dirs(p: &str) -> bool {
+    match create_dir_all(p) {
+        Ok(_) => true,
+        Err(e) => {
+            match e.kind() {
+                io::ErrorKind::PermissionDenied => {
+                    eprintln!("Cannot create directory due to permission errors");
+                    false
+                }
+                io::ErrorKind::AlreadyExists => true,
+                _ => false,
+            }
+        }
+    }
+}
+
+pub fn is_file_empty(f: File) -> bool {
+    let mut reader = BufReader::new(f);
+    let mut data = Vec::new();
+    let l = reader.read_to_end(&mut data).expect("stream did not contain valid UTF-8");
+    println!("{:?} {:?}", data, l);
+    !!data.is_empty()
+}
+
+pub fn find_items(file: &mut File, time: i64, l: i64) -> Vec<RollingData> {
+    let datetime_min: DateTime<Utc> = DateTime::from_utc(NaiveDateTime::from_timestamp(time, 0), Utc);
+    let datetime_max: DateTime<Utc> = datetime_min + chrono::Duration::minutes(l);
+    let mut data:String = String::new();
+    file.seek(SeekFrom::Start(0)).unwrap();
+    file.read_to_string(&mut data).unwrap();
+    let mut reader = csv::ReaderBuilder::new().from_reader(data.as_bytes());
+    reader.deserialize()
+        .collect::<Result<Vec<RollingData>, csv::Error>>().unwrap().into_iter().filter(|x| {
+        x.write_timestamp.ge(&datetime_min) && x.write_timestamp.lt(&datetime_max)
+    }).collect::<Vec<RollingData>>()
+}
+
+
+#[cfg(test)]
+mod utils_test {
+    use crate::utils::{create_dirs, find_items, is_file_empty, sanitize_string};
+    use std::fs::{File, OpenOptions, remove_dir_all, remove_file};
+    use std::io::{Read, Write};
+    use chrono::{TimeZone, Utc};
+    use serial_test::serial;
+    use crate::RollingData;
+
+
+    fn create_file(s: &str) -> File {
+        OpenOptions::new()
+            .write(true)
+            .append(true)
+            .create(true)
+            .read(true)
+            .open(s).unwrap()
+    }
+
+    #[test]
+    fn check_sanitize_string_with_semi_colons() {
+        let string = "BINANCE:BTCUSDT";
+        let got = sanitize_string(string);
+        assert_eq!(got, "BINANCE_BTCUSDT".to_string())
+    }
+
+    #[test]
+    fn check_sanitize_string_with_special_char() {
+        let string = "M$FT";
+        let got = sanitize_string(string);
+        assert_eq!(got, "M_FT".to_string())
+    }
+
+    #[test]
+    fn check_create_dirs() {
+        let path = "./tmp/data";
+        let got = create_dirs(path);
+        assert_eq!(got, true);
+        remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn try_create_dir_in_root() {
+        let path = "/finnhub-ws";
+        let got = create_dirs(path);
+        assert_eq!(got, false)
+    }
+
+    #[test]
+    #[serial]
+    fn check_if_non_empty_file_is_empty() {
+        let file_name = "test/non_empty.txt";
+        create_dirs("test");
+        let mut file = create_file(file_name);
+        file.write_all(b"this is not an empty file").unwrap();
+        // TODO: implement the test in a sane manner.
+        drop(file);
+        let file = create_file(file_name);
+        let got = is_file_empty(file);
+        assert_eq!(got, false);
+        remove_file(file_name).unwrap();
+        remove_dir_all("test").unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn check_if_actually_empty_file_is_empty() {
+        let file_name = "test/empty.txt";
+        create_dirs("test");
+        let file = create_file(file_name);
+        let got = is_file_empty(file);
+        assert_eq!(got, true);
+        remove_file(file_name).unwrap();
+        remove_dir_all("test").unwrap();
+    }
+
+    fn write_to_file(f: &mut File) {
+        f.write(b"Symbol,Price,Timestamp,WriteTimestamp
+BINANCE:BTCUSDT,23061.05,1658441258376,1658441270794
+BINANCE:BTCUSDT,23060.16,1658441258197,1658441270794
+BINANCE:BTCUSDT,23061.04,1658441258362,1658441270795
+BINANCE:BTCUSDT,23060.88,1658441258330,1658441270797
+BINANCE:BTCUSDT,23061.05,1658441258362,1658441270797
+BINANCE:BTCUSDT,23060.89,1658441258340,1658441270814
+BINANCE:BTCUSDT,23058.59,1658441258404,1658441271008
+BINANCE:BTCUSDT,23061.79,1658441258466,1658441271009").unwrap();
+    }
+
+    pub fn find_items_test(mut file: File, time: i64, l: i64) -> Vec<RollingData> {
+        let d: &mut String = &mut "".to_string();
+        file.read_to_string(d).unwrap();
+        let mut reader = csv::ReaderBuilder::new().from_reader(d.as_bytes());
+        let mut records: Vec<RollingData> = vec![];
+        for item in  reader.records(){
+            let record= item.unwrap();
+            records.push(RollingData {
+                symbol: record[0].parse().unwrap(),
+                price: record[1].parse().unwrap(),
+                timestamp: Utc.timestamp_millis(record[2].parse().unwrap()),
+                write_timestamp: Utc.timestamp_millis(record[3].parse().unwrap())
+            });
+        }
+        records
+    }
+
+    #[test]
+    #[serial]
+    fn write_to_disk() {
+        let file_name = "test/test.csv";
+        create_dirs("test");
+        let mut file = create_file(file_name);
+        write_to_file(&mut file);
+        let got = find_items(&mut file, 1658441258, 1);
+        let expected = vec![
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23061.05, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 376), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 794) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23060.16, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 197), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 794) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23061.04, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 362), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 795) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23060.88, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 330), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 797) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23061.05, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 362), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 797) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23060.89, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 340), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 50, 814) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23058.59, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 404), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 51, 8) },
+            RollingData { symbol: "BINANCE:BTCUSDT".parse().unwrap(), price: 23061.79, timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 38, 466), write_timestamp: Utc.ymd(2022, 7, 21).and_hms_milli(22, 7, 51, 9) },
+        ];
+        assert_eq!(got, expected);
+        remove_file(file_name).unwrap();
+        remove_dir_all("test").unwrap();
+    }
+}


### PR DESCRIPTION
This calculates the candlestick information for each stock that is being tracked and writes it back to a file. As a candlestick we define the following structure 
```rust
pub struct Candlestick {
    pub open_price: f64,
    pub close_price: f64,
    pub highest_price: f64,
    pub lowest_price: f64,
    pub trades_count: u64,
    minute_of_hour: chrono::DateTime<Utc> # having it truncated to the minute
}
```

It should implement the `CSVAble` trait so that it can be written back to a csv file for easier parsing later on. 


It also fixes a bug where the deserialization of the response of finnhub would be just a ping. It now deserializes the response as a `WsMessage`  